### PR TITLE
add mac verification on decryption

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,26 @@
+name: Go Test
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+    branches: ["master", "main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test ./...

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2019 TRON-US
+Copyright (c) 2025 Torus Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ecies_test.go
+++ b/ecies_test.go
@@ -1,8 +1,9 @@
 package go_eccrypto
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const msg = "hello,world\n"
@@ -13,7 +14,6 @@ const pkHex = "048903aca62f342426d0595597bcd4b03519723c7292f231a5d40c02" +
 const privHex = "0abfa58854e585d9bb04a1ffad0f5ac507ac042e7aa69abbcf18f3103a936f6f"
 
 func TestEncrypt(t *testing.T) {
-
 	twogBytes := make([]byte, 2*GB)
 	twogBytes[2*GB-1] = 1
 	_, _, err := Encrypt(pkHex, twogBytes)
@@ -25,4 +25,9 @@ func TestEncrypt(t *testing.T) {
 	decrypted, err := Decrypt(privHex, s, m)
 	assert.NoError(t, err)
 	assert.Equal(t, msg, decrypted)
+
+	// test invalid mac
+	m.Mac = "invalid"
+	_, err = Decrypt(privHex, s, m)
+	assert.Errorf(t, err, "")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/TRON-US/go-eccrypto
+module github.com/torusresearch/go-eccrypto
 
 go 1.13
 


### PR DESCRIPTION
`Decrypt` did not verify the MAC. This PR proposes to add MAC verification.